### PR TITLE
Mejoras menores y guía de uso

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Casa Biker Astro
+
+Este proyecto es un sitio web para una mecánica de motos totalmente administrable por el usuario. Utiliza [Astro](https://astro.build/) y [Supabase](https://supabase.com/) como backend.
+
+## Requisitos
+
+- Node.js 18 o superior
+- Una cuenta de Supabase con las tablas y buckets configurados
+
+## Instalación
+
+1. Clona el repositorio y entra en la carpeta:
+
+```bash
+npm install
+```
+
+2. Copia el archivo `.env.example` a `.env` y rellena tus claves de Supabase.
+
+3. Inicia el entorno de desarrollo:
+
+```bash
+npm run dev
+```
+
+## Scripts disponibles
+
+- `npm run dev` inicia Astro en modo desarrollo.
+- `npm run build` genera la versión estática del sitio en `dist/`.
+- `npm run preview` sirve la versión construida para pruebas.
+
+## Despliegue
+
+El proyecto se genera como sitio estático, por lo que puede desplegarse en cualquier hosting que sirva archivos estáticos.
+
+## Estructura básica
+
+- `src/` contiene el código fuente dividido en componentes, páginas, scripts y estilos.
+- `public/` almacena recursos estáticos como imágenes.
+
+Para cualquier duda adicional revisa los comentarios dentro del código.

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -90,7 +90,7 @@ const { title, user } = Astro.props;
       <p>&copy; {new Date().getFullYear()} Casa Biker. Todos los derechos reservados.</p>
     </footer>
   </div>
-  <script src="/src/scripts/theme-toggle.js"></script>
+  <script type="module" src="/src/scripts/theme-toggle.ts"></script>
 </body>
 </html>
 

--- a/src/scripts/theme-toggle.ts
+++ b/src/scripts/theme-toggle.ts
@@ -1,16 +1,18 @@
 const THEME_KEY = 'theme-preference';
 const THEME_TOGGLE_ID = 'theme-toggle';
-const DARK_THEME_CLASS = 'dark'; // Assuming you'll use a class on <html> or <body> like <html data-theme="dark">
+const DARK_THEME_CLASS = 'dark'; // Clase utilizada en <html data-theme="dark">
 
-const getThemePreference = () => {
-  const storedPreference = localStorage.getItem(THEME_KEY);
+type Theme = 'light' | 'dark';
+
+const getThemePreference = (): Theme => {
+  const storedPreference = localStorage.getItem(THEME_KEY) as Theme | null;
   if (storedPreference) {
     return storedPreference;
   }
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 };
 
-const setTheme = (theme) => {
+const setTheme = (theme: Theme): void => {
   localStorage.setItem(THEME_KEY, theme);
   document.documentElement.setAttribute('data-theme', theme); // Apply to <html>
   // Or if you prefer a class:
@@ -44,12 +46,10 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // Listen for system theme changes (optional, but good for consistency)
-  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-    // Only update if no manual preference is set or if you want to always follow system
-    // For now, let's assume manual override sticks.
-    // If you want it to re-evaluate if localStorage is not set:
-    // if (!localStorage.getItem(THEME_KEY)) {
-    //   setTheme(e.matches ? 'dark' : 'light');
-    // }
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  mediaQuery.addEventListener('change', () => {
+    if (!localStorage.getItem(THEME_KEY)) {
+      setTheme(mediaQuery.matches ? 'dark' : 'light');
+    }
   });
 });


### PR DESCRIPTION
## Resumen
- documento README con instrucciones en español
- migración de `theme-toggle` a TypeScript
- actualización de `AdminLayout` para cargar el nuevo script

## Testing
- `npm run build` *(falla: astro no está instalado)*

------
https://chatgpt.com/codex/tasks/task_e_684502d50a2c832cb27af54ba23a16d3